### PR TITLE
Update documentation to mention `#within` instead of `#with_transaction`

### DIFF
--- a/lib/dm-transactions.rb
+++ b/lib/dm-transactions.rb
@@ -347,7 +347,7 @@ module DataMapper
       #
       # @return [Adapters::Transaction]
       #   a new Transaction (in state :none) that can be used
-      #   to execute code #with_transaction
+      #   to execute code using #begin, #within and #commit
       #
       # @api public
       def transaction


### PR DESCRIPTION
The documentation refers to a `#with_transaction` method that is not in the current code. I suppose it has been moved to `#within` and the associated methods.
